### PR TITLE
Always use UTF-8 encoding for subcommand stdout

### DIFF
--- a/stats/analyzers/scc.py
+++ b/stats/analyzers/scc.py
@@ -19,7 +19,8 @@ def run(repository: Path, *, files_glob: str | None) -> AnalyzerResult:
             "--format",
             "json",
             str(repository),
-        ]
+        ],
+        encoding="utf-8",
     )
     scc_results = cast(list[dict[str, Any]], json.loads(output))
 

--- a/stats/git.py
+++ b/stats/git.py
@@ -29,6 +29,7 @@ def git(repository: Path, *args: str) -> str:
     process = subprocess.run(
         args,
         text=True,
+        encoding="utf-8",
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )


### PR DESCRIPTION
On Windows, this will default to CP1252, while the text itself is still
UTF-8, leading to text encoding errors.