### PR TITLE
Add grep_commits, an analyzer that greps through commit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ actually use grep(1).
 | `regex`            | Regular expression pattern to look for, make sure to escape properly | required |
 | `case_insensitive` | Whether to compile the pattern with `re.IGNORECASE`                  | false    |
 
+#### `grep_commits`
+
+Count occurrences of strings or regular expressions in commit messages.
+
+| Name               | Description                                                          | Default  |
+| :----------------- | :------------------------------------------------------------------- | :------- |
+| `regex`            | Regular expression pattern to look for, make sure to escape properly | required |
+| `case_insensitive` | Whether to compile the pattern with `re.IGNORECASE`                  | false    |
+
 #### `scc`
 
 Uses [scc(1)](https://github.com/boyter/scc) to generate per-file line count
@@ -170,7 +179,7 @@ stats.
 
 ## TODO
 
-Tests, more analyzers (e.g. for commit messages).
+Tests, more analyzers.
 
 ## License
 

--- a/stats/analyzers/__init__.py
+++ b/stats/analyzers/__init__.py
@@ -4,8 +4,13 @@ from functools import partial
 from pathlib import Path
 from typing import cast, Any, Callable, TypeAlias
 
-from stats.analyzers import grep as grep_analyzer, scc as scc_analyzer
+from stats.analyzers import (
+    grep as grep_analyzer,
+    grep_commits as grep_commits_analyzer,
+    scc as scc_analyzer,
+)
 from stats.config import AnalyzerConfig, Config
+from stats.git import Commit
 
 
 AnalyzerResult: TypeAlias = dict[str, Any]
@@ -16,18 +21,23 @@ def get_configured_analyzer_functions(
     analyzers: dict[str, AnalyzerConfig],
 ) -> dict[str, AnalyzerFunction]:
     return {
-        analyzer_name: partial(
-            {
-                Config.Analyzers.Grep: lambda: partial(
-                    grep_analyzer.run,
-                    regex=cast(Config.Analyzers.Grep, analyzer).regex,
-                    case_insensitive=cast(
-                        Config.Analyzers.Grep, analyzer
-                    ).case_insensitive,
-                ),
-                Config.Analyzers.SCC: lambda: partial(scc_analyzer.run),
-            }[type(analyzer)](),
-            files_glob=analyzer.files_glob,
-        )
+        analyzer_name: {
+            Config.Analyzers.Grep: lambda: partial(
+                grep_analyzer.run,
+                regex=cast(Config.Analyzers.Grep, analyzer).regex,
+                case_insensitive=cast(Config.Analyzers.Grep, analyzer).case_insensitive,
+                files_glob=analyzer.files_glob,
+            ),
+            Config.Analyzers.GrepCommits: lambda: partial(
+                grep_commits_analyzer.run,
+                regex=cast(Config.Analyzers.GrepCommits, analyzer).regex,
+                case_insensitive=cast(
+                    Config.Analyzers.GrepCommits, analyzer
+                ).case_insensitive,
+            ),
+            Config.Analyzers.SCC: lambda: partial(
+                scc_analyzer.run, files_glob=analyzer.files_glob
+            ),
+        }[type(analyzer)]()
         for analyzer_name, analyzer in analyzers.items()
     }

--- a/stats/analyzers/grep_commits.py
+++ b/stats/analyzers/grep_commits.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from stats.git import Commit, get_commit_texts
+
+if TYPE_CHECKING:
+    from stats.analyzers import AnalyzerResult
+
+
+def run(repository: Path, *, regex: str, case_insensitive: bool) -> AnalyzerResult:
+    pattern = re.compile(
+        regex,
+        re.IGNORECASE if case_insensitive else re.NOFLAG,
+    )
+    commit_text = get_commit_texts(repository)
+    matches = len(pattern.findall(commit_text))
+    return {"HEAD": matches}

--- a/stats/config.py
+++ b/stats/config.py
@@ -30,6 +30,11 @@ class Config:
             files_glob: str | None
 
         @dataclass
+        class GrepCommits:
+            regex: str
+            case_insensitive: bool
+
+        @dataclass
         class Grep(_Base):
             regex: str
             case_insensitive: bool
@@ -79,6 +84,12 @@ def load_config(path: Path) -> Config:
                 {
                     "grep": lambda: Config.Analyzers.Grep(
                         files_glob=cast(str | None, analyzer_config.get("files_glob")),
+                        regex=cast(str, analyzer_config["regex"]),
+                        case_insensitive=cast(
+                            bool, analyzer_config.get("case_insensitive", False)
+                        ),
+                    ),
+                    "grep_commits": lambda: Config.Analyzers.GrepCommits(
                         regex=cast(str, analyzer_config["regex"]),
                         case_insensitive=cast(
                             bool, analyzer_config.get("case_insensitive", False)

--- a/stats/git.py
+++ b/stats/git.py
@@ -63,3 +63,7 @@ def get_files(repository: Path) -> Iterator[Path]:
         # Git also lists symlinks, skip those.
         if (path := repository / line).is_file():
             yield path
+
+
+def get_commit_texts(repository: Path) -> str:
+    return git(repository, "log", "--pretty=format:%B", "HEAD~1..HEAD")


### PR DESCRIPTION
Output from the unmodified grep plotter, since the format is compatible; all commit messages from spcasm grepped for dependabot updates:

![Figure_1](https://user-images.githubusercontent.com/28656157/228912414-4c3a770b-cbec-4c89-9c69-f6d75b87fda8.png)
